### PR TITLE
Removes bootstrap-related code from gulpfile

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -103,8 +103,7 @@ gulp.task('wiredep', function () {
         .pipe(gulp.dest('app/styles'));
     gulp.src('app/*.html')
         .pipe(wiredep({
-            directory: 'app/bower_components',
-            exclude: ['bootstrap-sass-official']
+            directory: 'app/bower_components'
         }))
         .pipe(gulp.dest('app'));
 });


### PR DESCRIPTION
There is a line in the Gulpfile excluding 'bootstrap-sass-official' from bower_components in the wiredep task. I assume this was just copied from the [generator-gulp-bootstrap](https://github.com/niallobrien/generator-gulp-bootstrap) project, but it should be safe to remove this.
