### PR TITLE
Use `@import` instead of `@include`

### DIFF
--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,5 +1,5 @@
 // bower:scss
-@include "../bower_components/foundation/scss/foundation";
+@import "../bower_components/foundation/scss/foundation";
 // endbower
 
 // Custom imports & styles here.


### PR DESCRIPTION
`@include` fires an error in gulp-sass preventing the .scss from compiling.